### PR TITLE
Add part_of_speech, status fields; lowercase en fields

### DIFF
--- a/dictionary.toml
+++ b/dictionary.toml
@@ -231,6 +231,7 @@ part_of_speech = "noun"
 description = ""
 pronunciation_uz = ""
 similar = [""]
+status = "Pending review"
 
 [[translations]]
 en = "error"


### PR DESCRIPTION
What's in this pull request:
- added new fields: part_of_speech, status
  - part_of_speech field helps differentiate entries for the same word when it is used as a verb and a noun
  - status accepts one of these values: "Pending review", "Approved", "Deprecated", "Do not translate"
- lowercase en fields